### PR TITLE
fix(logging): log missing/remaining IPs on metadata validation timeout

### DIFF
--- a/pkg/factory/aliyun/aliyun.go
+++ b/pkg/factory/aliyun/aliyun.go
@@ -504,16 +504,39 @@ func (a *Aliyun) GetAttachedNetworkInterface(trunkENIID string) ([]*daemon.ENI, 
 }
 
 func validateIPInMetadata(ctx context.Context, expect []netip.Addr, getExist func() []netip.Addr) error {
-	return wait.PollUntilContextTimeout(ctx, metadataPollInterval, metadataWaitTimeout, false, func(ctx context.Context) (bool, error) {
-		exists := getExist()
-		return sets.New[netip.Addr](exists...).HasAll(expect...), nil
+	var lastExist []netip.Addr
+	err := wait.PollUntilContextTimeout(ctx, metadataPollInterval, metadataWaitTimeout, false, func(ctx context.Context) (bool, error) {
+		lastExist = getExist()
+		return sets.New[netip.Addr](lastExist...).HasAll(expect...), nil
 	})
+	if err != nil {
+		existSet := sets.New[netip.Addr](lastExist...)
+		var missing []netip.Addr
+		for _, ip := range expect {
+			if !existSet.Has(ip) {
+				missing = append(missing, ip)
+			}
+		}
+		klog.Errorf("validateIPInMetadata: timeout, expect %v, missing %v, metadata has %v", expect, missing, lastExist)
+	}
+	return err
 }
 
 func validateIPNotInMetadata(ctx context.Context, gone []netip.Addr, getExist func() []netip.Addr) error {
-	return wait.PollUntilContextTimeout(ctx, metadataPollInterval, metadataWaitTimeout, false, func(ctx context.Context) (bool, error) {
-		exists := getExist()
-
-		return !sets.New[netip.Addr](exists...).HasAny(gone...), nil
+	var lastExist []netip.Addr
+	err := wait.PollUntilContextTimeout(ctx, metadataPollInterval, metadataWaitTimeout, false, func(ctx context.Context) (bool, error) {
+		lastExist = getExist()
+		return !sets.New[netip.Addr](lastExist...).HasAny(gone...), nil
 	})
+	if err != nil {
+		existSet := sets.New[netip.Addr](lastExist...)
+		var remaining []netip.Addr
+		for _, ip := range gone {
+			if existSet.Has(ip) {
+				remaining = append(remaining, ip)
+			}
+		}
+		klog.Errorf("validateIPNotInMetadata: timeout, expect gone %v, still present %v, metadata has %v", gone, remaining, lastExist)
+	}
+	return err
 }


### PR DESCRIPTION
## Summary
- When `validateIPInMetadata` or `validateIPNotInMetadata` times out, log which IPs are missing or still present along with the full metadata server state
- Helps operators diagnose metadata sync issues without needing to manually correlate logs

## Test plan
- [x] Deployed `terway:23b7a7b4` to ACK cluster `cd58da21ea4404cfda7426f589247b34e`
- [x] Blocked meta server (100.100.100.200) via iptables on test node
- [x] Created pods to trigger IP allocation, confirmed new log format:
  ```
  validateIPInMetadata: timeout, expect [10.205.200.144 ...], missing [10.205.200.144 ...], metadata has []
  ```
- [x] Verified both `validateIPInMetadata` (assign IP) and create ENI paths produce correct diagnostic logs